### PR TITLE
Extraction of correct X-point positions on the dayside

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -19,48 +19,63 @@ except FileExistsError:
 
 Re = 6700000 # Earth's radius in m's / constant declaration
 
-for t in range(3600, 4201):
-    # Reading simulation data
+
+# Choose spatial domain
+if args.dayside:
+    xmin = -20
+    xmax = 9
+    zmin = -8
+    zmax = 8
+else:
+    xmin = -30
+    xmax = -5
+    zmin = -5
+    zmax = 5
+
+boxre = [xmin, xmax, zmin, zmax]
+
+
+for t in range(3700, 4200):
+
+######### LOADING Xpoints for ground truth
+    x_loc_dir='/proj/ivanzait/x_points_calc/'
+    x_loc_file='x_point_location_'+str(t)+'.txt'
+
+    Re=6371000
+
+    with open(x_loc_dir+x_loc_file) as f:
+        lines=f.readlines()
+
+    x_xp_array=[]
+    z_xp_array=[]
+
+    for k in range(len(lines)):       
+        lineK=lines[k]    
+        splitted=lineK.split(" ")
+        x_xp=np.divide(float(splitted[0]),Re)
+        z_xp=np.divide(float(splitted[2]),Re)
+        x_xp_array.append(x_xp) # x position of Xpoint
+        z_xp_array.append(z_xp) # z position of Xpoint
+
+
+    ### Selecting X-points within the domain
+    labeling_x=[]
+    labeling_z=[]
+    for kkk in range(0,np.array(x_xp_array).shape[0]):
+        if x_xp_array[kkk] > xmin and x_xp_array[kkk] < xmax and z_xp_array[kkk] > zmin and z_xp_array[kkk] < zmax :
+            labeling_x.append(x_xp_array[kkk])
+            labeling_z.append(z_xp_array[kkk])
+    
+         
+######### READING the simulation data
+    
     base_path = '/wrk/group/spacephysics/vlasiator/2D/BCH/'
     bulk_path = f'{base_path}/bulk/'
     file_name = f'bulk.000{str(t)}.vlsv'
     file = pt.vlsvfile.VlsvReader(bulk_path + file_name)
-
-    # Extracting positions of X-points
-    tarfile_name = 'BCH_X_n_O.tar'
-    txt_file_name = f'x_and_o_points/x_point_location_{str(t)}.txt'
-    tar = tarfile.open(base_path + tarfile_name)
-    tar.extract(txt_file_name, 'x_points')
-    untar_name=f'x_points/{txt_file_name}'
-
-    with open(untar_name) as f:
-        lines = f.readlines()
-
-    x_xp_array = []
-    z_xp_array = []
-
-    for k in range(len(lines)):       
-        lineK = lines[k]    
-        splitted = lineK.split(' ')
-        x_xp = np.divide(float(splitted[0]), Re)
-        z_xp = np.divide(float(splitted[2]), Re)
-        x_xp_array.append(x_xp) # x position of Xpoint
-        z_xp_array.append(z_xp) # z position of Xpoint
-
-    # Choose spatial domain
-    if args.dayside:
-        xmin = -20
-        xmax = 9
-        zmin = -8
-        zmax = 8
-    else:
-        xmin = -30
-        xmax = -5
-        zmin = -5
-        zmax = 5
     
-    boxre = [xmin, xmax, zmin, zmax]
     
+    #### Normalization
     anisotropy, agyrotropy = norm3.normalization(
         filename=bulk_path + file_name, boxre=boxre,
         pass_vars=['anisotropy', 'agyrotropy']
@@ -85,25 +100,18 @@ for t in range(3600, 4201):
     vy = v[:,:,1]
     vz = v[:,:,2]
 
-    # Selecting X-points within the domain
-    labeling_x = []
-    labeling_z = []
-    for kkk in range(0,np.array(x_xp_array).shape[0]):
-        if x_xp_array[kkk] > xmin and x_xp_array[kkk] < xmax and z_xp_array[kkk] > zmin and z_xp_array[kkk] < zmax :
-            labeling_x.append(x_xp_array[kkk])
-            labeling_z.append(z_xp_array[kkk])   
-
     # Creating 1D arrays of X and Z coordinates 
     xx = np.linspace(xmin, xmax, (np.array(B).shape[1]))
     zz = np.linspace(zmin, zmax, (np.array(B).shape[0]))
 
-    # Labeling
+######## Labeling
     labeled_domain = np.zeros_like(B[:,:,0]) # Create zero matrix with size equal to spatial domain size
     for k in range(0,np.array(labeling_x).shape[0]): # Cycle over X-points
         idx_x = (np.abs(xx - np.array(labeling_x)[k])).argmin() # Column index of X-point pixel  
         idx_z = (np.abs(zz - np.array(labeling_z)[k])).argmin() # Row index of X-point pixel 
         labeled_domain[idx_z,idx_x] = 1 # Chabge 0 to 1 for the pixels with X-point
     
+######## Storing   
     data = {
         'Bx': Bx, 'By': By, 'Bz': Bz, 'rho': rho, 'Ex': Ex, 'Ey': Ey, 'Ez': Ez, 'vx': vx, 'vy': vy, 'vz': vz,
         'agyrotropy':agyrotropy, 'anisotropy': anisotropy, 'labeled_domain': labeled_domain,


### PR DESCRIPTION
I discovered that the data we used before for the ground truth (the X-points positions) is a bit incorrect. So, I recalculated the positions of X-points and stored it into the following directory: /proj/ivanzait/x_points_calc/. Let me know if you don't have an access for it, but it should be open.

Incorrect version with the red crosses.
<img width="906" alt="image" src="https://user-images.githubusercontent.com/93721679/199303531-3e3a64c0-f306-4539-b2da-e8bcc67e2e1b.png">
More valid with black crosses:
![image](https://user-images.githubusercontent.com/93721679/199303985-97e5cd32-d1b6-4672-b8a4-f453a20b949a.png)
